### PR TITLE
feat: noPadding prop on desktop and mobile preview component

### DIFF
--- a/packages/easy-email-editor/src/components/EmailEditor/components/DesktopEmailPreview/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/DesktopEmailPreview/index.tsx
@@ -8,7 +8,13 @@ import { classnames } from '@/utils/classnames';
 import { SYNC_SCROLL_ELEMENT_CLASS_NAME } from '@/constants';
 import { createPortal } from 'react-dom';
 
-export function DesktopEmailPreview() {
+export interface DesktopEmailPreviewProps {
+  noPadding?: boolean;
+}
+
+export const DesktopEmailPreview: React.FC<DesktopEmailPreviewProps> = ({
+  noPadding = false,
+}) => {
   const { activeTab } = useActiveTab();
   const { errMsg, reactNode } = usePreviewEmail();
 
@@ -66,10 +72,15 @@ export function DesktopEmailPreview() {
               overflow: 'auto',
               margin: 'auto',
 
-              paddingLeft: 10,
-              paddingRight: 10,
-              paddingTop: 40,
-              paddingBottom: 140,
+              ...(noPadding === true
+                ? {}
+                : {
+                  paddingLeft: 10,
+                  paddingRight: 10,
+                  paddingTop: 40,
+                  paddingBottom: 140,
+                }),
+
               boxSizing: 'border-box',
             }}
           >

--- a/packages/easy-email-editor/src/components/EmailEditor/components/MobileEmailPreview/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/MobileEmailPreview/index.tsx
@@ -11,7 +11,13 @@ import { useActiveTab } from '@/hooks/useActiveTab';
 const MOBILE_WIDTH = 320;
 const MOBILE_Height = 640;
 
-export function MobileEmailPreview() {
+export interface MobileEmailPreviewProps {
+  noPadding?: boolean;
+}
+
+export const MobileEmailPreview: React.FC<MobileEmailPreviewProps> = ({
+  noPadding = false,
+}) => {
   const { mobileWidth } = usePreviewEmail();
   const { activeTab } = useActiveTab();
 
@@ -36,7 +42,11 @@ export function MobileEmailPreview() {
         alignItems: 'center',
         justifyContent: 'center',
         overflow: 'auto',
-        padding: '10px 0px',
+        ...(noPadding === true
+          ? {}
+          : {
+              padding: '10px 0px',
+            }),
         boxSizing: 'border-box',
       }}
     >


### PR DESCRIPTION
Add a prop `noPadding` on `DesktopEmailPreview` and `MobileEmailPreview` components, so we can reuse them without the padding required by the editor, which is not used when we want to show the preview in our context.

| Before | After |
| --- | --- |
| <img width="485" alt="image" src="https://github.com/zalify/easy-email/assets/16029436/cd1ec16c-7f30-40dc-a37b-d24b839eeff4"> | <img width="484" alt="image" src="https://github.com/zalify/easy-email/assets/16029436/858cdbb9-dcd9-4be9-b055-11b435320cff"> |
| <img width="790" alt="image" src="https://github.com/zalify/easy-email/assets/16029436/e09ec1e7-2f52-422e-8343-f67884986a64"> | <img width="788" alt="image" src="https://github.com/zalify/easy-email/assets/16029436/87368ea1-167e-4997-a152-d9908efff902"> |


