### PR TITLE
Fix the type error in Section component

### DIFF
--- a/packages/easy-email-core/src/blocks/standard/Section/index.tsx
+++ b/packages/easy-email-core/src/blocks/standard/Section/index.tsx
@@ -18,7 +18,7 @@ export type ISection = IBlockData<
     border?: string;
     'border-radius'?: string;
     direction?: 'ltr' | 'rtl';
-    'full-width'?: 'ltr' | 'rtl';
+    'full-width'?: string;
     padding?: string;
     'text-align'?: CSSProperties['textAlign'];
     'max-width'?: string;


### PR DESCRIPTION
When I was studying the role of full width in the Seciton component, I found that the type is different from the one defined on mjml, so I fixed it