### PR TITLE
fix: fixed link color bug

### DIFF
--- a/packages/easy-email-extensions/src/components/Form/RichTextToolBar/components/Link/index.tsx
+++ b/packages/easy-email-extensions/src/components/Form/RichTextToolBar/components/Link/index.tsx
@@ -30,8 +30,8 @@ function getAnchorElement(
   return getAnchorElement(node.parentNode);
 }
 
-function getLinkNode(
-  currentRange: Range | null | undefined
+export function getLinkNode(
+  currentRange: Range | null | undefined,
 ): HTMLAnchorElement | null {
   let linkNode: HTMLAnchorElement | null = null;
   if (!currentRange) return null;

--- a/packages/easy-email-extensions/src/components/Form/RichTextToolBar/components/Tools/Tools.tsx
+++ b/packages/easy-email-extensions/src/components/Form/RichTextToolBar/components/Tools/Tools.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { ToolItem } from '../ToolItem';
-import { Link, LinkParams } from '../Link';
+import { getLinkNode, Link, LinkParams } from '../Link';
 import {
   FIXED_CONTAINER_ID,
   getShadowRoot,
@@ -75,6 +75,12 @@ export function Tools(props: ToolsProps) {
         if (insertMergeTagEle) {
           insertMergeTagEle.focus();
           setRangeByElement(insertMergeTagEle);
+        }
+      } else if (cmd === 'foreColor') {
+        document.execCommand(cmd, false, val);
+        let linkNode: HTMLAnchorElement | null = getLinkNode(selectionRange);
+        if (linkNode) {
+          linkNode.style.color = 'inherit';
         }
       } else {
         document.execCommand(cmd, false, val);


### PR DESCRIPTION
The cause of the incident was that when I was using it, I found that if I first set a font size for the text, wrap the line at will in the middle of the text, then insert a link, and then modify the color of the link, it would not work.
![image](https://github.com/user-attachments/assets/0b5d0e09-03f0-484c-817d-fc41674ec88e)
After checking the source code, I can see that the `font` tag has the `color` attribute, but the `a` tag applies the browser's default color, but I remember that the `color: inherit` attribute would be set to the `a` tag when creating the tag. I guess that when executing `document.execCommand ('foreColor', false, val)`, the`color`of the child element would be removed, causing this problem
![image](https://github.com/user-attachments/assets/ba7e379f-eca8-4a3a-bdbc-8e9be87fd523)
So my modification idea is to create the link, get the selected `a` tag, and then add `color: inherit` to its style. After testing, this problem can be solved, and the output results are also very good.