### PR TITLE
feat: add dark mode support for editor and preview

### DIFF
--- a/packages/easy-email-editor/src/components/EmailEditor/components/DesktopEmailPreview/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/DesktopEmailPreview/index.tsx
@@ -7,11 +7,11 @@ import { SyncScrollShadowDom } from '@/components/UI/SyncScrollShadowDom';
 import { classnames } from '@/utils/classnames';
 import { SYNC_SCROLL_ELEMENT_CLASS_NAME } from '@/constants';
 import { createPortal } from 'react-dom';
+import { LIGHT_BG_COLOR } from '@/components/Provider/DarkModeProvider';
 
 export function DesktopEmailPreview() {
   const { activeTab } = useActiveTab();
   const { errMsg, reactNode } = usePreviewEmail();
-
   const { pageData } = useEditorContext();
 
   const fonts = useMemo(() => {
@@ -65,12 +65,12 @@ export function DesktopEmailPreview() {
               height: '100%',
               overflow: 'auto',
               margin: 'auto',
-
               paddingLeft: 10,
               paddingRight: 10,
               paddingTop: 40,
-              paddingBottom: 140,
+              paddingBottom: 40,
               boxSizing: 'border-box',
+              backgroundColor: LIGHT_BG_COLOR,
             }}
           >
             <>{reactNode}</>

--- a/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/components/MjmlDomRender.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/components/MjmlDomRender.tsx
@@ -8,6 +8,11 @@ import { createPortal } from 'react-dom';
 import { useEditorProps } from '@/hooks/useEditorProps';
 import { getEditorRoot, getShadowRoot } from '@/utils';
 import { DATA_RENDER_COUNT, FIXED_CONTAINER_ID } from '@/constants';
+import {
+  useDarkMode,
+  LIGHT_TEXT_COLOR,
+  DARK_TEXT_COLOR,
+} from '@/components/Provider/DarkModeProvider';
 
 let count = 0;
 export function MjmlDomRender() {
@@ -16,6 +21,7 @@ export function MjmlDomRender() {
   const [ref, setRef] = useState<HTMLDivElement | null>(null);
   const { dashed, mergeTags, enabledMergeTagsBadge } = useEditorProps();
   const [isTextFocus, setIsTextFocus] = useState(false);
+  const { isDarkMode } = useDarkMode();
 
   const isTextFocusing =
     document.activeElement === getEditorRoot() &&
@@ -69,17 +75,31 @@ export function MjmlDomRender() {
   const html = useMemo(() => {
     if (!pageData) return '';
 
+    const renderPageData =
+      isDarkMode && pageData.data.value['text-color'] === LIGHT_TEXT_COLOR
+        ? {
+            ...pageData,
+            data: {
+              ...pageData.data,
+              value: {
+                ...pageData.data.value,
+                'text-color': DARK_TEXT_COLOR,
+              },
+            },
+          }
+        : pageData;
+
     const renderHtml = mjml(
       JsonToMjml({
-        data: pageData,
+        data: renderPageData,
         idx: getPageIdx(),
-        context: pageData,
+        context: renderPageData,
         mode: 'testing',
         dataSource: cloneDeep(mergeTags),
       }),
     ).html;
     return renderHtml;
-  }, [mergeTags, pageData]);
+  }, [isDarkMode, mergeTags, pageData]);
 
   return useMemo(() => {
     return (

--- a/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/components/ShadowStyle.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/components/ShadowStyle.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import iconfontText from '@/assets/font/iconfont.css?inline';
 import styles from '@/styles/block-shadowDom-interactive.css?inline';
 import { useEditorProps } from '@/hooks/useEditorProps';
+import {
+  useDarkMode,
+  DARK_EDITOR_CSS_RAW,
+} from '@/components/Provider/DarkModeProvider';
 
 export function ShadowStyle() {
   const {
@@ -10,6 +14,8 @@ export function ShadowStyle() {
       selectedColor = 'rgb(var(--primary-6, #1890ff))',
     } = {},
   } = useEditorProps();
+
+  const { isDarkMode } = useDarkMode();
 
   return (
     <>
@@ -40,9 +46,9 @@ export function ShadowStyle() {
               -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
             }
 
-
             ${styles}
 
+            ${isDarkMode ? DARK_EDITOR_CSS_RAW : ''}
             `,
         }}
       />

--- a/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/EditEmailPreview/index.tsx
@@ -60,6 +60,7 @@ export function EditEmailPreview() {
             paddingTop: 40,
             paddingBottom: 40,
             boxSizing: 'border-box',
+            backgroundColor: '#ffffff',
           }}
           ref={setContainerRef}
 

--- a/packages/easy-email-editor/src/components/EmailEditor/components/MobileEmailPreview/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/components/MobileEmailPreview/index.tsx
@@ -12,10 +12,8 @@ const MOBILE_WIDTH = 320;
 const MOBILE_Height = 640;
 
 export function MobileEmailPreview() {
-  const { mobileWidth } = usePreviewEmail();
+  const { mobileWidth, errMsg, reactNode } = usePreviewEmail();
   const { activeTab } = useActiveTab();
-
-  const { errMsg, reactNode } = usePreviewEmail();
 
   const isActive = activeTab === ActiveTabKeys.MOBILE;
 
@@ -38,6 +36,7 @@ export function MobileEmailPreview() {
         overflow: 'auto',
         padding: '10px 0px',
         boxSizing: 'border-box',
+        backgroundColor: '#ffffff',
       }}
     >
       <div

--- a/packages/easy-email-editor/src/components/EmailEditor/index.tsx
+++ b/packages/easy-email-editor/src/components/EmailEditor/index.tsx
@@ -11,6 +11,7 @@ import { EditEmailPreview } from './components/EditEmailPreview';
 import { IconFont } from '../IconFont';
 import { TabPane, Tabs } from '@/components/UI/Tabs';
 import { useEditorProps } from '@/hooks/useEditorProps';
+import { useDarkMode } from '../Provider/DarkModeProvider';
 import './index.scss';
 import '@/assets/font/iconfont.css';
 import { EventManager, EventType } from '@/utils/EventManager';
@@ -20,6 +21,7 @@ import { EventManager, EventType } from '@/utils/EventManager';
 export const EmailEditor = () => {
   const { height: containerHeight } = useEditorProps();
   const { setActiveTab, activeTab } = useActiveTab();
+  const { isDarkMode, toggleDarkMode } = useDarkMode();
 
   const fixedContainer = useMemo(() => {
     return createPortal(<div id={FIXED_CONTAINER_ID} />, document.body);
@@ -29,9 +31,21 @@ export const EmailEditor = () => {
     return EventManager.exec(EventType.ACTIVE_TAB_CHANGE, { currentTab, nextTab });
   }, []);
 
-  const onChangeTab = useCallback((nextTab: string) => {
-    setActiveTab(nextTab as any);
-  }, [setActiveTab]);
+  const onChangeTab = useCallback(
+    (nextTab: string) => {
+      setActiveTab(nextTab as any);
+    },
+    [setActiveTab],
+  );
+
+  const darkModeToggle = (
+    <IconFont
+      iconName={isDarkMode ? 'icon-eye' : 'icon-eye-invisible'}
+      title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={toggleDarkMode}
+      style={{ cursor: 'pointer' }}
+    />
+  );
 
   return useMemo(
     () => (
@@ -52,6 +66,7 @@ export const EmailEditor = () => {
           onChange={onChangeTab}
           style={{ height: '100%', width: '100%' }}
           tabBarExtraContent={<ToolsPanel />}
+          tabBarAfterContent={darkModeToggle}
         >
           <TabPane
             style={{ height: 'calc(100% - 50px)' }}
@@ -90,6 +105,13 @@ export const EmailEditor = () => {
         <>{fixedContainer}</>
       </div>
     ),
-    [activeTab, containerHeight, fixedContainer, onBeforeChangeTab, onChangeTab]
+    [
+      activeTab,
+      containerHeight,
+      fixedContainer,
+      onBeforeChangeTab,
+      onChangeTab,
+      darkModeToggle,
+    ],
   );
 };

--- a/packages/easy-email-editor/src/components/Provider/DarkModeProvider/darkModeCss.ts
+++ b/packages/easy-email-editor/src/components/Provider/DarkModeProvider/darkModeCss.ts
@@ -1,0 +1,146 @@
+const WHITE = '#ffffff';
+const BLACK = '#000000';
+
+export const LIGHT_TEXT_COLOR = BLACK;
+export const DARK_TEXT_COLOR = WHITE;
+export const LIGHT_BG_COLOR = WHITE;
+
+export const DARK_PAGE_BG = '#585652';
+export const DARK_BLOCK_BG = '#1e1e1e';
+const DARK_LINK_COLOR = '#5b9bd5';
+const DARK_BORDER_COLOR = '#444';
+
+// MJML outputs lowercase hex (#ffffff) with a space after the colon.
+const WHITE_HEX = '#ffffff';
+const WHITE_RGB = 'rgb(255, 255, 255)';
+
+function is(...parts: string[]) { return `:is(${parts.join(', ')})`; }
+
+// Editor: white OR no background (safe inside class-scoped selectors)
+const DEFAULT_BG = is(
+  `:not([style*="background"]):not([bgcolor])`,
+  `[style*="${WHITE_HEX}"]`,
+  `[style*="${WHITE_RGB}"]`,
+  `[bgcolor="${WHITE_HEX}"]`,
+);
+
+// Preview: only explicit white (no class guards, so unstyled elements are excluded)
+const EXPLICIT_WHITE_BG = is(
+  `[style*="background-color: ${WHITE_HEX}"]`,
+  `[style*="background-color:${WHITE_HEX}"]`,
+  `[style*="background-color: ${WHITE_RGB}"]`,
+  `[style*="background: ${WHITE_HEX}"]`,
+  `[style*="background:${WHITE_HEX}"]`,
+  `[bgcolor="${WHITE_HEX}"]`,
+);
+
+const WRAPPER_BLOCKS = is('.node-type-wrapper', '.node-type-advanced_wrapper');
+const HERO_BLOCKS    = is('.node-type-hero', '.node-type-advanced_hero');
+const CONTAINER_BLOCKS = is(
+  '.node-type-section', '.node-type-group', '.node-type-carousel',
+  '.node-type-accordion', '.node-type-navbar', '.node-type-social', '.node-type-table',
+  '.node-type-advanced_section', '.node-type-advanced_group', '.node-type-advanced_carousel',
+  '.node-type-advanced_accordion', '.node-type-advanced_navbar', '.node-type-advanced_social',
+  '.node-type-advanced_table',
+);
+const PREVIEW_ROOT = 'div[role="article"]';
+const EDITOR_ROOT = '.node-type-page';
+const EDITOR_DIRECT_SURFACE = 'div:not([id*="InteractivePrompt"])';
+
+function joinSelectors(selectors: string[]) {
+  return selectors.join(',\n');
+}
+
+function pageShellSelectors(root: string, firstSurface: string) {
+  return joinSelectors([
+    root,
+    `${root} > ${firstSurface}`,
+    `${root} > ${firstSurface} > table`,
+    `${root} > ${firstSurface} > table > tbody`,
+    `${root} > ${firstSurface} > table > tbody > tr`,
+    `${root} > ${firstSurface} > table > tbody > tr > td`,
+  ]);
+}
+
+function blockSurfaceSelectors(root: string, firstSurface: string, blocks: string) {
+  return joinSelectors([
+    `${root} ${blocks}.email-block${DEFAULT_BG}`,
+    `${root} ${blocks}.email-block > ${firstSurface}${DEFAULT_BG}`,
+    `${root} ${blocks}.email-block > table${DEFAULT_BG}`,
+    `${root} ${blocks}.email-block > table > tbody${DEFAULT_BG}`,
+    `${root} ${blocks}.email-block > table > tbody > tr${DEFAULT_BG}`,
+    `${root} ${blocks}.email-block > table > tbody > tr > td${DEFAULT_BG}`,
+  ]);
+}
+
+const DARK_EMAIL_CSS_RAW = `
+:root { color-scheme: dark; }
+
+${pageShellSelectors(PREVIEW_ROOT, 'div')} {
+  background-color: ${DARK_PAGE_BG} !important;
+  background: ${DARK_PAGE_BG} !important;
+}
+${PREVIEW_ROOT} { color: ${DARK_TEXT_COLOR} !important; }
+
+${PREVIEW_ROOT} a:not([style*='color']),
+${PREVIEW_ROOT} a span:not([style*='color']) {
+  color: ${DARK_LINK_COLOR} !important;
+}
+
+${PREVIEW_ROOT} table, ${PREVIEW_ROOT} td,
+${PREVIEW_ROOT} th, ${PREVIEW_ROOT} hr {
+  border-color: ${DARK_BORDER_COLOR} !important;
+}
+
+${PREVIEW_ROOT} table${EXPLICIT_WHITE_BG},
+${PREVIEW_ROOT} td${EXPLICIT_WHITE_BG},
+${PREVIEW_ROOT} th${EXPLICIT_WHITE_BG},
+${PREVIEW_ROOT} div${EXPLICIT_WHITE_BG} {
+  background-color: ${DARK_BLOCK_BG} !important;
+  background: ${DARK_BLOCK_BG} !important;
+}
+
+${PREVIEW_ROOT} img { opacity: 1 !important; }
+`;
+
+export const PREVIEW_BASE_CSS = '<style data-preview-base>div[role="article"]{padding-bottom:100px;box-sizing:border-box}</style>';
+
+export const DARK_EMAIL_CSS = `<style data-dark-email>${DARK_EMAIL_CSS_RAW}</style>`;
+
+export const DARK_EDITOR_CSS_RAW = `
+${pageShellSelectors(EDITOR_ROOT, EDITOR_DIRECT_SURFACE)} {
+  background-color: ${DARK_PAGE_BG} !important;
+  background: ${DARK_PAGE_BG} !important;
+}
+${EDITOR_ROOT} { color: ${DARK_TEXT_COLOR} !important; }
+
+${blockSurfaceSelectors(EDITOR_ROOT, EDITOR_DIRECT_SURFACE, WRAPPER_BLOCKS)} {
+  background-color: ${DARK_PAGE_BG} !important;
+  background: ${DARK_PAGE_BG} !important;
+}
+${blockSurfaceSelectors(EDITOR_ROOT, EDITOR_DIRECT_SURFACE, HERO_BLOCKS)} {
+  background-color: ${DARK_BLOCK_BG} !important;
+  background: ${DARK_BLOCK_BG} !important;
+}
+${blockSurfaceSelectors(EDITOR_ROOT, EDITOR_DIRECT_SURFACE, CONTAINER_BLOCKS)} {
+  background-color: ${DARK_BLOCK_BG} !important;
+  background: ${DARK_BLOCK_BG} !important;
+}
+
+[id*="InteractivePrompt"] {
+  background-color: transparent !important;
+  background: transparent !important;
+}
+
+${EDITOR_ROOT} a:not([style*='color']),
+${EDITOR_ROOT} a span:not([style*='color']) {
+  color: ${DARK_LINK_COLOR} !important;
+}
+
+${EDITOR_ROOT} table, ${EDITOR_ROOT} td,
+${EDITOR_ROOT} th, ${EDITOR_ROOT} hr {
+  border-color: ${DARK_BORDER_COLOR} !important;
+}
+
+${EDITOR_ROOT} img { opacity: 1 !important; }
+`;

--- a/packages/easy-email-editor/src/components/Provider/DarkModeProvider/index.tsx
+++ b/packages/easy-email-editor/src/components/Provider/DarkModeProvider/index.tsx
@@ -1,0 +1,37 @@
+import React, { useContext, useState, useCallback, useMemo } from 'react';
+
+export {
+  DARK_PAGE_BG,
+  PREVIEW_BASE_CSS,
+  DARK_EMAIL_CSS,
+  DARK_EDITOR_CSS_RAW,
+  LIGHT_TEXT_COLOR,
+  DARK_TEXT_COLOR,
+  LIGHT_BG_COLOR,
+} from './darkModeCss';
+
+interface DarkModeContextType {
+  isDarkMode: boolean;
+  toggleDarkMode: () => void;
+}
+
+const DarkModeContext = React.createContext<DarkModeContextType>({
+  isDarkMode: false,
+  toggleDarkMode: () => { },
+});
+
+export const useDarkMode = () => useContext(DarkModeContext);
+
+export const DarkModeProvider: React.FC<{ children?: React.ReactNode; }> = props => {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const toggleDarkMode = useCallback(() => setIsDarkMode(d => !d), []);
+
+  const value = useMemo(
+    () => ({ isDarkMode, toggleDarkMode }),
+    [isDarkMode, toggleDarkMode],
+  );
+
+  return (
+    <DarkModeContext.Provider value={value}>{props.children}</DarkModeContext.Provider>
+  );
+};

--- a/packages/easy-email-editor/src/components/Provider/EmailEditorProvider/index.tsx
+++ b/packages/easy-email-editor/src/components/Provider/EmailEditorProvider/index.tsx
@@ -11,11 +11,14 @@ import { Config, FormApi, FormState } from 'final-form';
 import setFieldTouched from 'final-form-set-field-touched';
 import { FocusBlockLayoutProvider } from '../FocusBlockLayoutProvider';
 import { PreviewEmailProvider } from '../PreviewEmailProvider';
+import { DarkModeProvider } from '../DarkModeProvider';
 import { LanguageProvider } from '../LanguageProvider';
 import { overrideErrorLog, restoreErrorLog } from '@/utils/logger';
 
-export interface EmailEditorProviderProps<T extends IEmailTemplate = any>
-  extends Omit<PropsProviderProps, 'children'> {
+export interface EmailEditorProviderProps<T extends IEmailTemplate = any> extends Omit<
+  PropsProviderProps,
+  'children'
+> {
   data: T;
   children: (
     props: FormState<T>,
@@ -60,19 +63,21 @@ export const EmailEditorProvider = <T extends any>(
         <>
           <PropsProvider {...props}>
             <LanguageProvider locale={props.locale}>
-              <PreviewEmailProvider>
-                <RecordProvider>
-                  <BlocksProvider>
-                    <HoverIdxProvider>
-                      <ScrollProvider>
-                        <FocusBlockLayoutProvider>
-                          <FormWrapper children={children} />
-                        </FocusBlockLayoutProvider>
-                      </ScrollProvider>
-                    </HoverIdxProvider>
-                  </BlocksProvider>
-                </RecordProvider>
-              </PreviewEmailProvider>
+              <DarkModeProvider>
+                <PreviewEmailProvider>
+                  <RecordProvider>
+                    <BlocksProvider>
+                      <HoverIdxProvider>
+                        <ScrollProvider>
+                          <FocusBlockLayoutProvider>
+                            <FormWrapper children={children} />
+                          </FocusBlockLayoutProvider>
+                        </ScrollProvider>
+                      </HoverIdxProvider>
+                    </BlocksProvider>
+                  </RecordProvider>
+                </PreviewEmailProvider>
+              </DarkModeProvider>
             </LanguageProvider>
           </PropsProvider>
           <RegisterFields />

--- a/packages/easy-email-editor/src/components/Provider/PreviewEmailProvider/index.tsx
+++ b/packages/easy-email-editor/src/components/Provider/PreviewEmailProvider/index.tsx
@@ -6,6 +6,13 @@ import { JsonToMjml } from 'easy-email-core';
 import { cloneDeep, isString } from 'lodash';
 import mjml from 'mjml-browser';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useDarkMode,
+  PREVIEW_BASE_CSS,
+  DARK_EMAIL_CSS,
+  LIGHT_TEXT_COLOR,
+  DARK_TEXT_COLOR,
+} from '../DarkModeProvider';
 
 export const MOBILE_WIDTH = 320;
 
@@ -21,7 +28,7 @@ export const PreviewEmailContext = React.createContext<{
   mobileWidth: 320,
 });
 
-export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode }> = props => {
+export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode; }> = props => {
   const { current: iframe } = useRef(document.createElement('iframe'));
   const contentWindowRef = useRef<Window | null>(null);
 
@@ -32,6 +39,7 @@ export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode }> = pr
   const [errMsg, setErrMsg] = useState<React.ReactNode>('');
   const [html, setHtml] = useState('');
   const lazyPageData = useLazyState(pageData, 0);
+  const { isDarkMode } = useDarkMode();
 
   const injectData = useMemo(() => {
     if (previewInjectData) {
@@ -54,6 +62,10 @@ export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode }> = pr
         value: {
           ...lazyPageData.data.value,
           breakpoint: adjustBreakPoint + 'px',
+          'text-color':
+            isDarkMode && lazyPageData.data.value['text-color'] === LIGHT_TEXT_COLOR
+              ? DARK_TEXT_COLOR
+              : lazyPageData.data.value['text-color'],
         },
       },
     };
@@ -63,9 +75,11 @@ export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode }> = pr
         mode: 'production',
         context: cloneData,
         dataSource: cloneDeep(injectData),
-        keepClassName: true,
       }),
     ).html;
+
+    parseHtml = parseHtml.replace('</head>', PREVIEW_BASE_CSS + (isDarkMode ? DARK_EMAIL_CSS : '') + '</head>');
+
     if (onBeforePreview) {
       try {
         const result = onBeforePreview(parseHtml, injectData);
@@ -90,7 +104,7 @@ export const PreviewEmailProvider: React.FC<{ children?: React.ReactNode }> = pr
     return () => {
       setHtml('');
     };
-  }, [injectData, onBeforePreview, lazyPageData, mobileWidth]);
+  }, [injectData, onBeforePreview, lazyPageData, mobileWidth, isDarkMode]);
 
   const htmlNode = useMemo(() => HtmlStringToPreviewReactNodes(html), [html]);
 

--- a/packages/easy-email-editor/src/components/UI/Tabs/index.tsx
+++ b/packages/easy-email-editor/src/components/UI/Tabs/index.tsx
@@ -7,6 +7,7 @@ import './index.scss';
 export interface TabsProps {
   children?: React.ReactNode;
   tabBarExtraContent?: React.ReactNode;
+  tabBarAfterContent?: React.ReactNode;
   style?: React.CSSProperties;
   className?: string;
   onChange?: (id: string) => void;
@@ -79,6 +80,7 @@ const Tabs: React.FC<TabsProps> = props => {
                 );
               },
             )}
+            {props.tabBarAfterContent}
           </Stack>
           {props.tabBarExtraContent}
         </Stack>

--- a/packages/easy-email-editor/src/index.tsx
+++ b/packages/easy-email-editor/src/index.tsx
@@ -28,6 +28,7 @@ export * from './hooks/useFocusIdx';
 export * from './hooks/useHoverIdx';
 
 export { ActiveTabKeys } from './components/Provider/BlocksProvider';
+export { useDarkMode } from './components/Provider/DarkModeProvider';
 
 // UI
 export { IconFont } from './components/IconFont';

--- a/packages/easy-email-editor/src/utils/HtmlStringToPreviewReactNodes.tsx
+++ b/packages/easy-email-editor/src/utils/HtmlStringToPreviewReactNodes.tsx
@@ -8,12 +8,29 @@ export function getChildSelector(selector: string, index: number) {
   return `${selector}-${index}`;
 }
 
-export function HtmlStringToPreviewReactNodes(
-  content: string,
-) {
-  let doc = domParser.parseFromString(content, 'text/html'); // The average time is about 1.4 ms
+export function HtmlStringToPreviewReactNodes(content: string) {
+  let doc = domParser.parseFromString(content, 'text/html');
+  const headStyleNodes = [...doc.head.querySelectorAll('style')].map((node, index) => (
+    <RenderReactNode
+      selector={getChildSelector(getChildSelector('0', 0), index)}
+      node={node as any}
+      index={index}
+      key={`head-style-${index}`}
+    />
+  ));
+  const bodyNodes = [...doc.body.childNodes].map((node, index) => (
+    <RenderReactNode
+      selector={getChildSelector(getChildSelector('0', 1), index)}
+      node={node as any}
+      index={index}
+      key={`body-${index}`}
+    />
+  ));
   const reactNode = (
-    <RenderReactNode selector={'0'} node={doc.documentElement} index={0} />
+    <>
+      {headStyleNodes}
+      {bodyNodes}
+    </>
   );
 
   return reactNode;
@@ -31,7 +48,7 @@ const RenderReactNode = React.memo(function ({
   const attributes: { [key: string]: string; } = {
     'data-selector': selector,
   };
-  node.getAttributeNames?.().forEach((att) => {
+  node.getAttributeNames?.().forEach(att => {
     if (att) {
       attributes[att] = node.getAttribute(att) || '';
     }


### PR DESCRIPTION
This is a feature that I wrote for my own purposes using Claude Code, Figured I'd submit a PR.

I tried my best to get the editor to mirror what you'd see in an email client (in this case outlook). The only thing I could not workout was using a sun/moon for dark mode since it was not an icon font. It's using a substitute 'eye'.
<br>
<img width="254" height="62" alt="image" src="https://github.com/user-attachments/assets/018c40e5-816d-4ec8-b9ba-f11d23bd9c14" />
<br>

> Adds a dark mode toggle to the email editor that applies a dark theme across the edit view, desktop preview, and mobile preview. The dark theme preserves authored block backgrounds and explicit text/link colors, only inverting the page shell and default/white backgrounds — so the email layout looks as close as possible to how a dark-mode email client would render it.
> 
> DarkModeProvider (new) — React context wrapping the editor tree, exposes isDarkMode + toggleDarkMode. Hook exported as useDarkMode() from the package root.
> 
> darkModeCss.ts (new) — Single source of truth for dark mode colours and two CSS blocks: DARK_EMAIL_CSS (injected into preview iframe HTML) and DARK_EDITOR_CSS_RAW (injected into the edit view). Editor CSS targets white and unset backgrounds within class-scoped block selectors; preview CSS targets only explicit white backgrounds, so transparent inner cells inherit their parent block's authored color.
> 
> EmailEditorProvider — DarkModeProvider added as outermost wrapper.
> 
> EmailEditor — Toggle button added to the tab bar via tabBarAfterContent.
> 
> MjmlDomRender — In dark mode, overrides the default text-color to white before passing to mjml(). Form data is never mutated.
> 
> PreviewEmailProvider — Text-color override applied for preview, and DARK_EMAIL_CSS injected into the HTML string before iframe write.

Outlook messes with the colors a little but the core concept is there.

Editor:
<img width="1019" height="1118" alt="image" src="https://github.com/user-attachments/assets/6b82c9e5-028c-4c45-9d18-70a06dd536e0" />


Outlook:

<img width="755" height="1005" alt="image" src="https://github.com/user-attachments/assets/ce857240-0025-4fec-a21c-f8015bcdd847" />