### PR TITLE
fix: correct off-by-one error in moveBlock when reordering within the…

### DIFF
--- a/packages/easy-email-editor/src/hooks/useBlock.ts
+++ b/packages/easy-email-editor/src/hooks/useBlock.ts
@@ -148,7 +148,8 @@ export function useBlock() {
 
       const positionIndex = getIndexByIdx(destinationIdx);
       if (sourceParent === destinationParent) {
-        destinationParent.children.splice(positionIndex, 0, removed);
+        const adjustedPosition = sourceIndex < positionIndex ? positionIndex - 1 : positionIndex;
+        destinationParent.children.splice(adjustedPosition, 0, removed);
 
         nextFocusIdx =
           destinationParentIdx +


### PR DESCRIPTION
… same parent

When dragging a block to a higher index within the same parent, the source block is removed first which shifts all subsequent indices down by 1. The destination index was not adjusted to account for this, causing the block to be inserted one position too far down.